### PR TITLE
[Remove] requirement for teamcity.step.mode = "default"

### DIFF
--- a/teamcity/resource_build_configuration.go
+++ b/teamcity/resource_build_configuration.go
@@ -520,6 +520,10 @@ func resourceBuildConfigurationReadInternal(d *schema.ResourceData, meta interfa
 		}
 		properties := make(map[string]interface{})
 		for name, prop := range step.Properties {
+			if properties[name] == "teamcity.step.mode" {
+				continue
+			}
+
 			properties[name] = prop
 		}
 		if len(properties) > 0 {

--- a/test2.tf
+++ b/test2.tf
@@ -10,3 +10,18 @@ resource "teamcity_project" "default" {
     # validation_mode = "any"
   }
 }
+
+resource "teamcity_build_configuration" "default" {
+  project = "${teamcity_project.default.id}"
+  name    = "default-build-configuration"
+
+  step {
+    type = "simpleRunner"
+    name = "second"
+
+    properties = {
+      script.content    = "echo 'Terraform'"
+      use.custom.script = "true"
+    }
+  }
+}


### PR DESCRIPTION
This can still be overridden with the value being defined but currently I see no reason for this to be defined its just a waste of lines. Mostly because this is actually a constant in Teamcity
```
teamcity.step.mode = "default"
```

is auotmatically skilled on read of TF which means TF will never see it